### PR TITLE
Fix post operator ++ and --

### DIFF
--- a/src/Expr.cpp
+++ b/src/Expr.cpp
@@ -21,8 +21,8 @@ std::any Literal::accept(ExprVisitor &visitor){
   return visitor.visitLiteralExpr(shared_from_this());
 }
 
-Unary::Unary(Token oper, std::shared_ptr<Expr> right) : 
-  oper{std::move(oper)}, right{std::move(right)} {}
+Unary::Unary(Token oper, std::shared_ptr<Expr> right, bool isPost) : 
+  oper{std::move(oper)}, right{std::move(right)}, isPostOperator{isPost} {}
 
 std::any Unary::accept(ExprVisitor &visitor){
   return visitor.visitUnaryExpr(shared_from_this());

--- a/src/Expr.hpp
+++ b/src/Expr.hpp
@@ -34,8 +34,9 @@ struct Literal final: Expr, public std::enable_shared_from_this<Literal> {
 struct Unary final: Expr, public std::enable_shared_from_this<Unary> {
   Token oper;
   std::shared_ptr<Expr> right;
+  bool isPostOperator;
 
-  Unary(Token oper, std::shared_ptr<Expr> right);
+  Unary(Token oper, std::shared_ptr<Expr> right, bool isPostOperator);
   std::any accept(ExprVisitor &visitor) override;
   ~Unary() = default;
 };

--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -29,6 +29,9 @@ std::any Interpreter::visitUnaryExpr(std::shared_ptr<Unary> expr){
       if (auto varExpr = std::dynamic_pointer_cast<Variable>(expr->right)) {
         curr_env->assign(varExpr->name, right);
       }
+      if (expr->isPostOperator) {
+        return std::any_cast<double>(right) - 1;
+      }
       return right;
 
     case TokenType::MINUS_MINUS:
@@ -36,6 +39,9 @@ std::any Interpreter::visitUnaryExpr(std::shared_ptr<Unary> expr){
       right = std::any_cast<double>(right) - 1;
       if (auto varExpr = std::dynamic_pointer_cast<Variable>(expr->right)) {
         curr_env->assign(varExpr->name, right);
+      }
+      if (expr->isPostOperator) {
+        return std::any_cast<double>(right) + 1;
       }
       return right;
 

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -80,7 +80,7 @@ std::shared_ptr<Expr> Parser::unary(){
     }
     matchVoid(TokenType::SEMICOLON);
 
-    return std::make_shared<Unary>(oper, right);
+    return std::make_shared<Unary>(oper, right, false);
   }
   return call();
 }
@@ -95,7 +95,7 @@ std::shared_ptr<Expr> Parser::primary(){
     if (match(TokenType::PLUS_PLUS, TokenType::MINUS_MINUS)) {
       Token oper = previous();
       matchVoid(TokenType::SEMICOLON);
-      return std::make_shared<Unary>(oper, left);
+      return std::make_shared<Unary>(oper, left, true);
     }
     return left;
   }

--- a/tests/incdec.ter
+++ b/tests/incdec.ter
@@ -1,0 +1,9 @@
+auto a=1
+output("    Increment")
+  out(a++) out("|")
+  out(a) out("|")
+  output(++a)
+output("    Decrement")
+  out(a--) out("|")
+  out(a) out("|")
+  output(--a)

--- a/tests/incdec.ter.result
+++ b/tests/incdec.ter.result
@@ -1,0 +1,4 @@
+    Increment
+1|2|3
+    Decrement
+3|2|1


### PR DESCRIPTION
Post increment and post decrement were not working as expected. They shall use the current value and update memory for next use. To reach that, unary constructor was modified to accept a third argument isPostOperator of type bool. Then, when processing the unary operator, if it is post operator, the return value is returned unchanged.